### PR TITLE
修复难度值溢出问题

### DIFF
--- a/etc/index.html
+++ b/etc/index.html
@@ -59,7 +59,7 @@
     <h1>Tinychain Websocket Page</h1>
 
     <p>
-      This page demonstrates how Tinychain works. commands are: getnewaccount; startmining $address; send $amount $address;
+      This page demonstrates how Tinychain works. commands are: getnewaccount; startmining $address; send $address $amount;
     </p>
 
     <div id="messages">

--- a/src/consensus.cpp
+++ b/src/consensus.cpp
@@ -53,7 +53,10 @@ bool miner::pow_once(block& new_block, address_t& addr) {
     if (time_peroid <= 10u) {
         new_block.header_.difficulty = prev_block.header_.difficulty + 9000;
     } else {
-        new_block.header_.difficulty = prev_block.header_.difficulty - 3000;
+        if (prev_block.header_.difficulty <= 3000)
+            new_block.header_.difficulty = prev_block.header_.difficulty + 9000;
+        else
+            new_block.header_.difficulty = prev_block.header_.difficulty - 3000;
     }
     // 计算挖矿目标值,最大值除以难度就目标值
     uint64_t target = 0xffffffffffffffff / prev_block.header_.difficulty;


### PR DESCRIPTION
如果第二个块的时间戳比初始块的时间戳大了超过10s，第二个块难度值会溢出，导致cpu在短时间内飙到很高。
另外，index.html的send参数有点小问题~